### PR TITLE
fix: prevent duplicate scripts in onboarding wizard

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -194,35 +194,29 @@ function amp_init() {
 	 * Detects whether the current window is in an iframe with the specified `name` attribute. The iframe is created
 	 * by Preview component located in <assets/src/setup/pages/save/index.js>.
 	 */
+
+
 	add_action(
-		'wp_print_footer_scripts',
+		'wp_head',
 		function() {
-			if ( ! amp_is_dev_mode() || ! is_admin_bar_showing() ) {
-				return;
+			if ( isset( $_SERVER['HTTP_SEC_FETCH_DEST'] ) && 'iframe' === $_SERVER['HTTP_SEC_FETCH_DEST'] ) {
+				?>
+					<style>
+						html:not(#_) {
+							margin-top: 0 !important;
+						}
+						#wpadminbar {
+							display: none !important;
+						}
+					</style>
+					<?php
 			}
-			?>
-			<script data-ampdevmode>
-				document.addEventListener( 'DOMContentLoaded', function() {
-					if ( 'amp-wizard-completion-preview' !== window.name ) {
-						return;
-					}
-
-					/** @type {HTMLStyleElement} */
-					const style = document.createElement( 'style' );
-					style.setAttribute( 'type', 'text/css' );
-					style.appendChild( document.createTextNode( 'html:not(#_) { margin-top: 0 !important; } #wpadminbar { display: none !important; }' ) );
-					document.head.appendChild( style );
-
-					const adminBar = document.getElementById( 'wpadminbar' );
-					if ( adminBar ) {
-						document.body.classList.remove( 'admin-bar' );
-						adminBar.remove();
-					}
-				});
-			</script>
-			<?php
 		}
 	);
+
+
+
+
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -195,28 +195,40 @@ function amp_init() {
 	 * by Preview component located in <assets/src/setup/pages/save/index.js>.
 	 */
 
+	add_action( 'wp_head', 'amp_wp_remove_adminbar_onboard_iframe' );
+	add_action( 'amp_post_template_head', 'amp_wp_remove_adminbar_onboard_iframe' );
 
-	add_action(
-		'wp_head',
-		function() {
-			if ( isset( $_SERVER['HTTP_SEC_FETCH_DEST'] ) && 'iframe' === $_SERVER['HTTP_SEC_FETCH_DEST'] ) {
-				?>
-					<style>
-						html:not(#_) {
-							margin-top: 0 !important;
-						}
-						#wpadminbar {
-							display: none !important;
-						}
-					</style>
-					<?php
-			}
+	/*
+	 * Remove the adminbar on iframe preview of site in AMP Onboarding Wizard
+	 */
+	function amp_wp_remove_adminbar_onboard_iframe() {
+		if ( isset( $_SERVER['HTTP_SEC_FETCH_DEST'] ) && 'iframe' !== $_SERVER['HTTP_SEC_FETCH_DEST'] ) {
+			return;
 		}
-	);
+		?>
+		<style>
+			html:not(#_) {
+				margin-top: 0 !important;
+			}
+			#wpadminbar {
+				display: none !important;
+			}
+		</style>
+		<script type="text/javascript" data-ampdevmode >
+			document.addEventListener( 'DOMContentLoaded', function() {
+				if ( 'amp-wizard-completion-preview' !== window.name ) {
+					return;
+				}
+				const adminBar = document.getElementById( 'wpadminbar' );
+				if ( adminBar ) {
+					document.body.classList.remove( 'admin-bar' );
+					adminBar.remove();
+				}
 
-
-
-
+			} );
+		</script>
+		<?php
+	}
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -195,14 +195,14 @@ function amp_init() {
 	 * by Preview component located in <assets/src/setup/pages/save/index.js>.
 	 */
 	add_action(
-		'wp_print_scripts',
+		'wp_print_footer_scripts',
 		function() {
 			if ( ! amp_is_dev_mode() || ! is_admin_bar_showing() ) {
 				return;
 			}
 			?>
 			<script data-ampdevmode>
-				( () => {
+				document.addEventListener( 'DOMContentLoaded', function() {
 					if ( 'amp-wizard-completion-preview' !== window.name ) {
 						return;
 					}
@@ -213,14 +213,12 @@ function amp_init() {
 					style.appendChild( document.createTextNode( 'html:not(#_) { margin-top: 0 !important; } #wpadminbar { display: none !important; }' ) );
 					document.head.appendChild( style );
 
-					document.addEventListener( 'DOMContentLoaded', function() {
-						const adminBar = document.getElementById( 'wpadminbar' );
-						if ( adminBar ) {
-							document.body.classList.remove( 'admin-bar' );
-							adminBar.remove();
-						}
-					});
-				} )();
+					const adminBar = document.getElementById( 'wpadminbar' );
+					if ( adminBar ) {
+						document.body.classList.remove( 'admin-bar' );
+						adminBar.remove();
+					}
+				});
 			</script>
 			<?php
 		}


### PR DESCRIPTION
Print scripts only in footer instead of header and footer

## Summary

<!-- Please reference the issue(s) this PR fixes, if one exists. For significant changes, opening an issue first for discussion is usually preferable. -->

## Checklist

- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/wiki/Engineering-Guidelines) (updates are often made to the guidelines, check it out periodically).
